### PR TITLE
Fix FTBFS with GCC -Werror=format-security

### DIFF
--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -19,7 +19,7 @@ char errorbuff[10000];
 void check_log(char*fn_to_check, char*msg){
 #ifdef HAVE_FMEMOPEN
     fflush(NULL);
-    Apop_stopif (!apop_regex(errorbuff, fn_to_check), abort(), 0, msg);
+    Apop_stopif (!apop_regex(errorbuff, fn_to_check), abort(), 0, "%s", msg);
 #endif
 }
 


### PR DESCRIPTION
This commit will fix the FTBFS issue with -Werror=format-security enabled.

Details: https://fedoraproject.org/wiki/Format-Security-FAQ
