### PR TITLE
library version update wrt libtool versionning scheme

### DIFF
--- a/install/Makefile.am
+++ b/install/Makefile.am
@@ -8,7 +8,9 @@ AUTOMAKE_OPTIONS = \
 AM_CFLAGS = -g -Wall -O3
 
 ## Library versioning (C:R:A == current:revision:age)
-LIBAPOPHENIA_LT_VERSION = 0:0:0
+## 0.999b 0:0:0
+## 0.999c 1:0:0
+LIBAPOPHENIA_LT_VERSION = 1:0:0
 
 SUBDIRS = transform model . cmd tests docs eg
 

--- a/install/apophenia.map
+++ b/install/apophenia.map
@@ -1,4 +1,4 @@
-LIBAPOPHENIA_0.0.0 {
+LIBAPOPHENIA_1.0.0 {
 global:
 apop_opts;
 apop_name_alloc;


### PR DESCRIPTION
Update the library version wrt to the LibTool Manual (section 7.3) and the related material.
This patch was extracted from the Debian package version 0.999c+ds-1.
