### PR TITLE
Update configure.ac

### DIFF
--- a/install/configure.ac
+++ b/install/configure.ac
@@ -11,6 +11,7 @@ AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE
 AM_MAINTAINER_MODE
+AM_INIT_AUTOMAKE([subdir-objects])
 
 # The normal /usr/local default confused too many people
 ##AC_PREFIX_DEFAULT([/usr])


### PR DESCRIPTION
This line will prevent errors such as the following on Mac OS X:
    automake: warning: source file '$(top_builddir)/eg/apop_map_row.c' is in a subdirectory,
    automake: but option 'subdir-objects' is disabled