### PR TITLE
Update apop_internal.h

### DIFF
--- a/apop_internal.h
+++ b/apop_internal.h
@@ -62,7 +62,7 @@ void apop_gsl_error(char const *reason, char const *file, int line, int gsl_errn
 #else
 #define OMP_critical(tag)
 #define OMP_for(...) for(__VA_ARGS__)
-#define OMP_for_reduce(...) for(__VA_ARGS__)
+#define OMP_for_reduce(red, ...) for(__VA_ARGS__)
 #endif
 
 #include "config.h"


### PR DESCRIPTION
If _OPENMP not defined the OMP_for_reduce macro needs to consume the red argument before generating the for loop code.