### PR TITLE
autotools chain: tests: harden (builddir)

### DIFF
--- a/eg/logit.c
+++ b/eg/logit.c
@@ -1,10 +1,17 @@
 // See http://modelingwithdata.org/arch/00000160.htm for context and analysis.
+
+#ifdef Datadir
+#define DATADIR Datadir
+#else
+#define DATADIR "."
+#endif
+
 #include <apop.h>
 
 int main(){
     //read the data to db, get the desired columns,
     //prep the two categorical variables
-    apop_text_to_db("amash_vote_analysis.csv", .tabname="amash");
+    apop_text_to_db( DATADIR "/" "amash_vote_analysis.csv" , .tabname="amash");
     apop_data *d = apop_query_to_mixed_data("mmmtt", "select 0, ideology,log(contribs+10) as contribs, vote, party from amash");
     apop_data_to_factors(d); //0th text col -> 0th matrix col
     apop_data_to_dummies(d, .col=1, .type='t', .append='y');

--- a/eg/ols.c
+++ b/eg/ols.c
@@ -1,7 +1,13 @@
+#ifdef Datadir
+#define DATADIR Datadir
+#else
+#define DATADIR "."
+#endif
+
 #include <apop.h>
 
 int main(){
-    apop_text_to_db(.text_file="data", .tabname="d");
+    apop_text_to_db(.text_file= DATADIR "/" "data" , .tabname="d");
     apop_data *data = apop_query_to_data("select * from d");
     apop_model *est = apop_estimate(data, apop_ols);
     apop_model_print(est);

--- a/eg/ols_oneliner.c
+++ b/eg/ols_oneliner.c
@@ -1,2 +1,8 @@
+#ifdef Datadir
+#define DATADIR Datadir
+#else
+#define DATADIR "."
+#endif
+
 #include <apop.h>
-int main(){ apop_model_print(apop_estimate(apop_text_to_data("data"), apop_ols)); }
+int main(){ apop_model_print(apop_estimate(apop_text_to_data( DATADIR "/" "data" ), apop_ols)); }

--- a/eg/simple_subsets.c
+++ b/eg/simple_subsets.c
@@ -1,20 +1,26 @@
+#ifdef Datadir
+#define DATADIR Datadir
+#else
+#define DATADIR "."
+#endif
+
 #include <apop.h>
 
 int main(){
-    apop_table_exists("data", 'd');
-    apop_data *d = apop_text_to_data("data");
-  
+    apop_table_exists( DATADIR "/" "data" , 'd');
+    apop_data *d = apop_text_to_data( DATADIR "/" "data" );
+
     //tally row zero of the data set's matrix by viewing it as a vector:
     gsl_vector *one_row = Apop_rv(d, 0);
     double sigma = apop_vector_sum(one_row);
     printf("Sum of row zero: %g\n", sigma);
     assert(sigma==14);
-  
+
     //view column zero as a vector; take its mean
     double mu = apop_vector_mean(Apop_cv(d, 0));
     printf("Mean of col zero: %g\n", mu);
     assert(fabs(mu - 19./6)<1e-5);
-  
+
     //get a sub-data set (with names) of two rows beginning at row 3; print to screen
     apop_data *six_elmts = Apop_rs(d, 3, 2);
     apop_data_print(six_elmts);

--- a/tests/sort_example.c
+++ b/tests/sort_example.c
@@ -1,3 +1,9 @@
+#ifdef Datadir
+#define DATADIR Datadir
+#else
+#define DATADIR "."
+#endif
+
 #include <apop.h>
 #include <unistd.h>
 #ifdef Testing
@@ -8,8 +14,8 @@
 double get_distance(gsl_vector *v) {return apop_vector_distance(v);}
 
 int main(){
-    apop_text_to_db("amash_vote_analysis.csv");
-    apop_data *d = apop_query_to_mixed_data("mntmtm", "select 1,id,party,contribs/1000.0,vote,ideology from amash_vote_analysis ");
+    apop_text_to_db( DATADIR "/" "amash_vote_analysis.csv" );
+    apop_data *d = apop_query_to_mixed_data("mntmtm", "select 1,id,party,contribs/1000.0,vote,ideology from amash_vote_analysis " );
 
     //use the default order of columns for sorting
     apop_data *sorted = apop_data_sort(d, .inplace='n');
@@ -43,7 +49,7 @@ int main(){
 
     //take each row of the matrix as a vector; store the Euclidian distance to the origin in the vector;
     //sort in descending order.
-    apop_data *rowvectors = apop_text_to_data("test_data");
+    apop_data *rowvectors = apop_text_to_data( DATADIR "/" "test_data" );
     apop_map(rowvectors, .fn_v=get_distance, .part='r', .inplace='y');
     apop_data *arow = apop_data_copy(Apop_r(rowvectors, 0));
     arow->matrix=NULL; //sort only by the distance vector


### PR DESCRIPTION
Micro fixes to harden external building.
Nevertheless a minor bug persists in `tests/sort_example.c'

============================================
   apophenia 0.999e: tests/test-suite.log
============================================

# TOTAL: 30
# PASS:  29
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: sort_example
==================

<unknown>: create table  ( 'id' numeric,  'party' numeric,  'ideology' numeric,  'vote' numeric,  'contribs' numeric);: near "(": syntax error
tab_create_sqlite: query "create table  ( 'id' numeric,  'party' numeric,  'ideology' numeric,  'vote' numeric,  'contribs' numeric);" failed.
apop_text_to_db_base: Creating the table in the database failed.
apop_sqlite_multiquery: select 1,id,party,contribs/1000.0,vote,ideology from amash_vote_analysis : no such table: amash_vote_analysis
apop_data_copy: the data set to be copied has an error flag of q. Copying it.
gsl: init.c:33: ERROR: permutation length n must be positive integer
Default GSL error handler invoked.


