### PR TITLE
autotools chains: extented tests: harden (external builddir)

### DIFF
--- a/eg/f_test.c
+++ b/eg/f_test.c
@@ -1,3 +1,9 @@
+#ifdef Datadir
+#define DATADIR Datadir
+#else
+#define DATADIR "."
+#endif
+
 #include <apop.h>
 
 #define Diff(L, R, eps) {double left=(L), right=(R); Apop_stopif(isnan(left-right) || fabs((left)-(right))>(eps), abort(), 0, "%g is too different from %g (abitrary limit=%g).", (double)(left), (double)(right), eps);}
@@ -25,7 +31,7 @@ void test_f(apop_model *est){
 }
 
 int main(){
-    apop_data *d = apop_text_to_data("test_data2");
+    apop_data *d = apop_text_to_data( DATADIR "/" "test_data2" );
     apop_model *an_ols_model = apop_model_copy(apop_ols);
     Apop_model_add_group(an_ols_model, apop_lm, .want_expected_value= 1);
     apop_model *e  = apop_estimate(d, an_ols_model);

--- a/install/Makefile.am
+++ b/install/Makefile.am
@@ -5,6 +5,10 @@ AUTOMAKE_OPTIONS = \
 	dist-bzip2 \
 	dist-zip
 
+AM_DISTCHECK_CONFIGURE_FLAGS ?= \
+	--disable-maintainer-mode \
+	--enable-extended-tests
+
 AM_CFLAGS = -g -Wall -O3
 
 ## Library versioning (C:R:A == current:revision:age)


### PR DESCRIPTION
The first patch correct a minor issue that occurs for extended-tests.
to reproduce the issue:

mkdir _BUILD
cd _BUILD
PATH_TO_APOPHENIA _SOURCE_FOLDER/configure --enable-extented-tests
make
make check

The second patch forces `make distcheck' to check against extended-tests