### PR TITLE
migration to C23: clean up

### DIFF
--- a/apop_mle.m4.c
+++ b/apop_mle.m4.c
@@ -365,7 +365,7 @@ static void fdf_shell(const gsl_vector *beta, void *i, double *f, gsl_vector *df
 }
 
 static int ctrl_c;
-static void mle_sigint(){ ctrl_c ++; }
+static void mle_sigint(int){ ctrl_c ++; }
 
 static int setup_starting_point(apop_mle_settings *mp, gsl_vector *x){
     Apop_stopif(!x, return -1, 0, "The vector I'm trying to optimize over is NULL.");
@@ -827,7 +827,7 @@ static void annealing_free(void *xp){
 static double set_start(double in){ return in ? in : 1; }
 
 jmp_buf anneal_jump;
-static void anneal_sigint(){ longjmp(anneal_jump,1); }
+static void anneal_sigint(int){ longjmp(anneal_jump,1); }
 
 static void apop_annealing(infostruct *i){
     apop_model *ep = i->model;

--- a/model/apop_loess.c
+++ b/model/apop_loess.c
@@ -3383,7 +3383,7 @@ double invigauss_quick(double p) {
  */
 
 static double invibeta_quick(double p, double a, double b) {
-  double x, m, s, invigauss_quick();
+  double x, m, s;
     x = a + b;
     m = a / x;
     s = sqrt((a*b) / (x*x*(x+1)));


### PR DESCRIPTION
Clean up now obsoleted declarations/definitions.
This patch closes Debian bug #1092385.